### PR TITLE
Feature: clamp method

### DIFF
--- a/src/base/maths.ts
+++ b/src/base/maths.ts
@@ -20,6 +20,21 @@ Scoped.define("module:Maths", [], function() {
         discreteCeil: function(number: number, steps: number, max: number): number {
             var x = Math.ceil(number / steps) * steps;
             return max && x > max ? 0 : x;
+        },
+
+        /**
+         * Clamps number between an upper and lower bound.
+         *
+         * @param {number} number the number to clamp
+         * @param {number} lower the lower bound
+         * @param {number} upper the upper bound
+         *
+         * @returns {number} the clamped number
+         */
+        clamp: function(number: number, lower: number = -Infinity, upper: number = Infinity): number {
+            if (number < lower) return lower;
+            if (number > upper) return upper;
+            return number;
         }
 
     };

--- a/tests/base/maths.js
+++ b/tests/base/maths.js
@@ -1,3 +1,18 @@
 QUnit.test("infinity", function (assert) {
 	assert.equal(!Infinity, false);
 });
+
+QUnit.test("clamp", function(assert) {
+	assert.strictEqual(BetaJS.Maths.clamp(5, 1, 7), 5);
+	assert.strictEqual(BetaJS.Maths.clamp(0, 1, 7), 1);
+	assert.strictEqual(BetaJS.Maths.clamp(10, 1, 7), 7);
+
+	assert.strictEqual(BetaJS.Maths.clamp(-5, -1, 7), -1);
+	assert.strictEqual(BetaJS.Maths.clamp(0, -7, -1), -1);
+	assert.strictEqual(BetaJS.Maths.clamp(-2, -3, 0), -2);
+
+	assert.strictEqual(BetaJS.Maths.clamp(-10.2, -5.5, 5.5), -5.5);
+	assert.strictEqual(BetaJS.Maths.clamp(-Infinity, -5.5, 5.5), -5.5);
+	assert.strictEqual(BetaJS.Maths.clamp(5, -Infinity, 5.5), 5);
+	assert.strictEqual(BetaJS.Maths.clamp(5.5, -Infinity, Infinity), 5.5);
+});


### PR DESCRIPTION
Created `clamp` function that clamps a value between an upper and lower bound.

Example use:
```js
BetaJS.Maths.clamp(5, 1, 7) // returns 5
BetaJS.Maths.clamp(1, 3, 7) // returns 3
BetaJS.Maths.clamp(10, 1, 7) // returns 7
```